### PR TITLE
Fixed preserved filter for django 1.7

### DIFF
--- a/polymorphic/admin.py
+++ b/polymorphic/admin.py
@@ -271,6 +271,16 @@ class PolymorphicParentModelAdmin(admin.ModelAdmin):
         real_admin = self._get_real_admin(object_id)
         return real_admin.delete_view(request, object_id, extra_context)
 
+    def get_preserved_filters(self, request):
+        if '_changelist_filters' in request.GET:
+            request.GET = request.GET.copy()
+            filters = request.GET.get('_changelist_filters')
+            f = filters.split("&")
+            for x in f:
+                c = x.split('=')
+                request.GET[c[0]] = c[1]
+            del request.GET['_changelist_filters']
+        return super(PolymorphicParentModelAdmin, self).get_preserved_filters(request)
 
     def get_urls(self):
         """


### PR DESCRIPTION
The problem occurs when you have a filter and create o delete a child, when is back to change list
the filter is lost, and have a e=-1 as a get parameter