### PR TITLE
Issue with related_name in polymorphic_ctype field

### DIFF
--- a/polymorphic/polymorphic_model.py
+++ b/polymorphic/polymorphic_model.py
@@ -56,7 +56,7 @@ class PolymorphicModel(six.with_metaclass(PolymorphicModelBase, models.Model)):
 
     # avoid ContentType related field accessor clash (an error emitted by model validation)
     polymorphic_ctype = models.ForeignKey(ContentType, null=True, editable=False,
-                                related_name='polymorphic_%(app_label)s.%(class)s_set')
+                                related_name='polymorphic_%(app_label)s.%(class)s_set+')
 
     # some applications want to know the name of the fields that are added to its models
     polymorphic_internal_model_fields = ['polymorphic_ctype']


### PR DESCRIPTION
Django 1.8b2 complains that the related name defined on polymorphic_ctype is not valid (due to this commit: django/django@1e5e2a470).

It requires either a valid Python identifier, or for the name to end in a '+'... so I added a '+' at the end.
Alternatively the period will have to be removed from the related name, and replaced with an underscore or something.

What do you think?