### PR TITLE
fixed Django 1.8 complain about related name

### DIFF
--- a/polymorphic/polymorphic_model.py
+++ b/polymorphic/polymorphic_model.py
@@ -56,7 +56,7 @@ class PolymorphicModel(six.with_metaclass(PolymorphicModelBase, models.Model)):
 
     # avoid ContentType related field accessor clash (an error emitted by model validation)
     polymorphic_ctype = models.ForeignKey(ContentType, null=True, editable=False,
-                                related_name='polymorphic_%(app_label)s.%(class)s_set')
+                                related_name='polymorphic_%(app_label)s%(class)s_set')
 
     # some applications want to know the name of the fields that are added to its models
     polymorphic_internal_model_fields = ['polymorphic_ctype']

--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -103,8 +103,9 @@ class PolymorphicQuerySet(QuerySet):
             else:
                 # With Django > 1.8, the field on which the aggregate operates is
                 # stored inside a query expression.
-                a.source_expressions[0].name = translate_polymorphic_field_path(
-                    self.model, a.source_expressions[0].name)
+                if hasattr(a, 'source_expressions'):
+                    a.source_expressions[0].name = translate_polymorphic_field_path(
+                        self.model, a.source_expressions[0].name)
 
         get_lookup = lambda a: a.lookup if django.VERSION < (1, 8) else a.source_expressions[0].name
 


### PR DESCRIPTION
Django 1.8 complains because of invalid regex. So, I tried to to remove . (dot) character and it worked.