### PR TITLE
Use parent admin site class for child admin site

### DIFF
--- a/polymorphic/admin.py
+++ b/polymorphic/admin.py
@@ -125,7 +125,7 @@ class PolymorphicParentModelAdmin(admin.ModelAdmin):
 
     def __init__(self, model, admin_site, *args, **kwargs):
         super(PolymorphicParentModelAdmin, self).__init__(model, admin_site, *args, **kwargs)
-        self._child_admin_site = AdminSite(name=self.admin_site.name)
+        self._child_admin_site = self.admin_site.__class__(name=self.admin_site.name)
         self._is_setup = False
 
 


### PR DESCRIPTION
Using the `AdminSite` class directly can cause issues when the parent
model is registered with a custom admin site class.

For example in my project I have a custom `User` model that doesn't have an `is_staff` flag. Since the `AdminSite.has_permission` method uses this flag, I had to override it in a custom admin site class. Now when `real_admin.change_view` is called, an error is raised because the original `AdminSite.has_permission` is executed instead of my custom method.