### PR TITLE
add base_model declaration to child models in admin docs example (docfix)

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -86,10 +86,12 @@ The models are taken from :ref:`advanced-features`.
 
 
     class ModelBAdmin(ModelAChildAdmin):
+        base_model = ModelB
         # define custom features here
 
 
     class ModelCAdmin(ModelBAdmin):
+        base_model = ModelC
         # define custom features here
 
 


### PR DESCRIPTION
Updates the example code in the admin section of the docs to reflect that "base_model should be set in [the child model admin] class as well." For those of us who don't read unless absolutely forced to...