### PR TITLE
Raise Http404 if object does not exist.

### DIFF
--- a/polymorphic/admin.py
+++ b/polymorphic/admin.py
@@ -198,7 +198,11 @@ class PolymorphicParentModelAdmin(admin.ModelAdmin):
 
 
     def _get_real_admin(self, object_id):
-        obj = self.model.objects.non_polymorphic().values('polymorphic_ctype').get(pk=object_id)
+        try:
+            obj = self.model.objects.non_polymorphic() \
+                .values('polymorphic_ctype').get(pk=object_id)
+        except self.model.DoesNotExist:
+            raise Http404
         return self._get_real_admin_by_ct(obj['polymorphic_ctype'])
 
 


### PR DESCRIPTION
When visiting the change form for a polymorphic model and providing a bogus primary key, we currently get a 500 error `ObjectDoesNotExist`. This change raises `Http404` instead.
