### PR TITLE
Test Django 1.8 with Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
     env: DJANGO=">=1.6,<1.7"
   - python: "3.5"
     env: DJANGO=">=1.7,<1.8"
-  - python: "3.5"
-    env: DJANGO=">=1.8,<1.9"
 
   - python: "3.4"
     env: DJANGO=">=1.4,<1.5"


### PR DESCRIPTION
Django's latest 1.8.X minor supports Python 3.5.