### PR TITLE
Update quickstart for Django 1.9 compatibility

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -12,7 +12,7 @@ Update the settings file::
         'django.contrib.contenttypes',
     )
 
-The current release of *django-polymorphic* supports Django 1.4 till 1.8 and Python 3 is supported.
+The current release of *django-polymorphic* supports Django 1.4 till 1.9 and Python 3 is supported.
 
 Making Your Models Polymorphic
 ------------------------------


### PR DESCRIPTION
The changelog states that 1.9 is supported, but the quickstart document has not yet been updated.