### PR TITLE
Re-add convenience imports back in using some module magic

### DIFF
--- a/polymorphic/__init__.py
+++ b/polymorphic/__init__.py
@@ -10,6 +10,9 @@ Please see LICENSE and AUTHORS for more information.
 __version__ = "0.9.1"
 
 
+import sys
+from types import ModuleType
+
 # Monkey-patch Django < 1.5 to allow ContentTypes for proxy models.
 import django
 if django.VERSION[:2] < (1, 5):
@@ -38,3 +41,58 @@ if django.VERSION[:2] < (1, 5):
 
     ContentTypeManager.get_for_model__original = ContentTypeManager.get_for_model
     ContentTypeManager.get_for_model = get_for_model
+
+
+# import mapping to objects in other modules
+all_by_module = {
+    'polymorphic.manager': ('PolymorphicManager', ),
+    'polymorphic.models': ('PolymorphicModel', ),
+    'polymorphic.query': ('PolymorphicQuerySet', ),
+    'polymorphic.query_translate': ('translate_polymorphic_Q_object', ),
+    'polymorphic.showfields': (
+        'ShowFieldContent', 'ShowFieldType', 'ShowFieldTypeAndContent',
+        # old names for compatibility
+        'ShowFields', 'ShowFieldTypes', 'ShowFieldsAndTypes',
+    ),
+}
+
+
+object_origins = {}
+for module, items in all_by_module.items():
+    for item in items:
+        object_origins[item] = module
+
+
+class module(ModuleType):
+
+    def __dir__(self):
+        """Just show what we want to show."""
+        result = list(new_module.__all__)
+        result.extend(('__file__', '__path__', '__doc__', '__all__',
+                       '__docformat__', '__name__', '__path__',
+                       '__package__', '__version__'))
+        return result
+
+    def __getattr__(self, name):
+        if name in object_origins:
+            module = __import__(object_origins[name], None, None, [name])
+            for extra_name in all_by_module[module.__name__]:
+                setattr(self, extra_name, getattr(module, extra_name))
+            return getattr(module, name)
+        return ModuleType.__getattribute__(self, name)
+
+
+# keep a reference to this module so that it's not garbage collected
+old_module = sys.modules[__name__]
+
+# setup the new module and patch it into the dict of loaded modules
+new_module = sys.modules[__name__] = module(__name__)
+new_module.__dict__.update({
+    '__file__':         __file__,
+    '__package__':      __package__,
+    '__path__':         __path__,
+    '__doc__':          __doc__,
+    '__version__':      __version__,
+    '__all__':          tuple(object_origins),
+    '__docformat__':    'restructuredtext en',
+})


### PR DESCRIPTION
The convenience imports in `polymorphic/__init__.py` were, for us, extremely convenient. There is a way to lazily allow these imports rather than automatically importing them on load, which gets around the issues with how Django 1.9+ requires a stricter order of imports. The principle behind it is stolen from [werkzeug](https://github.com/pallets/werkzeug/blob/41177bf0efc198383ce9e692ec62be8e5fb7fcff/werkzeug/__init__.py), and the hack of swapping in a class instance in `sys.modules` is [Guido approved](https://mail.python.org/pipermail/python-ideas/2012-May/014969.html).

