### PR TITLE
Issue #200 - Exclude super-class from proxy model query sets

### DIFF
--- a/polymorphic/managers.py
+++ b/polymorphic/managers.py
@@ -32,7 +32,10 @@ class PolymorphicManager(models.Manager):
         super(PolymorphicManager, self).__init__(*args, **kwrags)
 
     def get_queryset(self):
-        return self.queryset_class(self.model, using=self._db)
+        qs = self.queryset_class(self.model, using=self._db)
+        if self.model._meta.proxy:
+            qs = qs.instance_of(self.model)
+        return qs
 
     # For Django 1.5
     if django.VERSION < (1, 7):

--- a/polymorphic/tests.py
+++ b/polymorphic/tests.py
@@ -1006,6 +1006,16 @@ class PolymorphicTests(TestCase):
 
         self.assertIsInstance(items[0], ProxyChild)
 
+    def test_queryset_on_proxy_model_does_not_return_superclasses(self):
+        ProxyBase.objects.create(some_data='Base1')
+        ProxyBase.objects.create(some_data='Base2')
+        ProxyChild.objects.create(some_data='Child1')
+        ProxyChild.objects.create(some_data='Child2')
+        ProxyChild.objects.create(some_data='Child3')
+
+        self.assertEquals(5, ProxyBase.objects.count())
+        self.assertEquals(3, ProxyChild.objects.count())
+
     def test_proxy_get_real_instance_class(self):
         """
         The call to ``get_real_instance()`` also checks whether the returned model is of the correct type.
@@ -1020,7 +1030,7 @@ class PolymorphicTests(TestCase):
         self.assertEqual(pb.get_real_instance(), nonproxychild)
         self.assertEqual(pb.name, name)
 
-        pbm = ProxyChild.objects.get(id=1)
+        pbm = NonProxyChild.objects.get(id=1)
         self.assertEqual(pbm.get_real_instance_class(), NonProxyChild)
         self.assertEqual(pbm.get_real_instance(), nonproxychild)
         self.assertEqual(pbm.name, name)


### PR DESCRIPTION
These changes prevent the query sets on 'proxy' models from including
the items from the 'super-class'.

I'm not really sure if it is as simple as these change suggest, but...