### PR TITLE
#220 Pass hints to returned queryset in PolymorphicManager.get_queryset.

### DIFF
--- a/polymorphic/managers.py
+++ b/polymorphic/managers.py
@@ -32,7 +32,10 @@ class PolymorphicManager(models.Manager):
         super(PolymorphicManager, self).__init__(*args, **kwrags)
 
     def get_queryset(self):
-        qs = self.queryset_class(self.model, using=self._db, hints=self._hints)
+        if django.VERSION >= (1, 7):
+            qs = self.queryset_class(self.model, using=self._db, hints=self._hints)
+        else:
+            qs = self.queryset_class(self.model, using=self._db)
         if self.model._meta.proxy:
             qs = qs.instance_of(self.model)
         return qs

--- a/polymorphic/managers.py
+++ b/polymorphic/managers.py
@@ -32,7 +32,7 @@ class PolymorphicManager(models.Manager):
         super(PolymorphicManager, self).__init__(*args, **kwrags)
 
     def get_queryset(self):
-        qs = self.queryset_class(self.model, using=self._db)
+        qs = self.queryset_class(self.model, using=self._db, hints=self._hints)
         if self.model._meta.proxy:
             qs = qs.instance_of(self.model)
         return qs

--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -112,8 +112,8 @@ class PolymorphicQuerySet(QuerySet):
 
     def _filter_or_exclude(self, negate, *args, **kwargs):
         "We override this internal Django functon as it is used for all filter member functions."
-        q_objects = translate_polymorphic_filter_definitions_in_args(self.model, args, using=self._db)  # the Q objects
-        additional_args = translate_polymorphic_filter_definitions_in_kwargs(self.model, kwargs, using=self._db)  # filter_field='data'
+        q_objects = translate_polymorphic_filter_definitions_in_args(self.model, args, using=self.db)  # the Q objects
+        additional_args = translate_polymorphic_filter_definitions_in_kwargs(self.model, kwargs, using=self.db)  # filter_field='data'
         return super(PolymorphicQuerySet, self)._filter_or_exclude(negate, *(list(q_objects) + additional_args), **kwargs)
 
     def order_by(self, *args, **kwargs):
@@ -309,7 +309,7 @@ class PolymorphicQuerySet(QuerySet):
         # - also record the correct result order in "ordered_id_list"
         # - store objects that already have the correct class into "results"
         base_result_objects_by_id = {}
-        content_type_manager = ContentType.objects.db_manager(self._db)
+        content_type_manager = ContentType.objects.db_manager(self.db)
         self_model_class_id = content_type_manager.get_for_model(self.model, for_concrete_model=False).pk
         self_concrete_model_class_id = content_type_manager.get_for_model(self.model, for_concrete_model=True).pk
 
@@ -345,7 +345,7 @@ class PolymorphicQuerySet(QuerySet):
         # Then we copy the extra() select fields from the base objects to the real objects.
         # TODO: defer(), only(): support for these would be around here
         for real_concrete_class, idlist in idlist_per_model.items():
-            real_objects = real_concrete_class.base_objects.db_manager(self._db).filter(**{
+            real_objects = real_concrete_class.base_objects.db_manager(self.db).filter(**{
                 ('%s__in' % pk_name): idlist,
             })
             real_objects.query.select_related = self.query.select_related  # copy select related configuration to new qs

--- a/polymorphic/tests.py
+++ b/polymorphic/tests.py
@@ -1203,11 +1203,12 @@ class RegressionTests(TestCase):
 class MultipleDatabasesTests(TestCase):
     multi_db = True
 
+    @skipIf(django.VERSION < (1,5,), "This test needs Django >=1.5")
     def test_save_to_non_default_database(self):
         Model2A.objects.db_manager('secondary').create(field1='A1')
         Model2C(field1='C1', field2='C2', field3='C3').save(using='secondary')
         Model2B.objects.create(field1='B1', field2='B2')
-        Model2D(field1='D1', field2='D2', field3='D3', field4='D4').save('secondary')
+        Model2D(field1='D1', field2='D2', field3='D3', field4='D4').save()
 
         default_objects = list(Model2A.objects.order_by('id'))
         self.assertEqual(len(default_objects), 2)


### PR DESCRIPTION
- Pass hints to returned queryset in `PolymorphicManager.get_queryset()`.
- Use `self.db` instead of `self._db` in `PolymorphicQuerySet`.
- Add unit tests for related object queries using non-default databases.

Fixes #220.
