### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Django to perform an ``INNER JOIN`` to fetch the model fields from the database.
 While taking this in mind, there are valid reasons for using subclassed models.
 That's what this library is designed for!
 
-For more information, see the `documentation at Read the Docs <https://django-polymorphic.readthedocs.org/>`_.
+For more information, see the `documentation at Read the Docs <https://django-polymorphic.readthedocs.io/>`_.
 
 License
 =======

--- a/docs/third-party.rst
+++ b/docs/third-party.rst
@@ -10,7 +10,7 @@ However, they require more setup than standard models. That's become:
 * The children models are not registered in the admin site.
   You will therefore need to manually register them to django-reversion_.
 * Polymorphic models use `multi-table inheritance <https://docs.djangoproject.com/en/dev/topics/db/models/#multi-table-inheritance>`_.
-  See the `reversion documentation <http://django-reversion.readthedocs.org/en/latest/api.html#multi-table-inheritance>`_
+  See the `reversion documentation <https://django-reversion.readthedocs.io/en/latest/api.html#multi-table-inheritance>`_
   how to deal with this by adding a ``follow`` field for the primary key.
 * Both admin classes redefine ``object_history_template``.
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.